### PR TITLE
Improve search UI with pagination, sorting, and category filters

### DIFF
--- a/internal/frontend/static/styles.css
+++ b/internal/frontend/static/styles.css
@@ -34,26 +34,49 @@ body {
 
 .sf-main {
     flex: 1;
-    padding: 1.5rem;
-    max-width: 960px;
+    padding: 2rem 1.5rem;
+    max-width: 1280px;
     margin: 0 auto;
     width: 100%;
 }
 
-.sf-search {
+.sf-layout {
+    display: grid;
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: flex-start;
+}
+
+.sf-side,
+.sf-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.sf-search-card,
+.sf-results,
+.sf-scan {
     background: #ffffff;
-    border-radius: 12px;
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-    box-shadow: 0 6px 16px rgba(31, 60, 136, 0.12);
+    border-radius: 16px;
+    padding: 1.75rem;
+    box-shadow: 0 18px 32px rgba(31, 60, 136, 0.12);
+}
+
+.sf-search-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
 .sf-scan {
-    background: #ffffff;
-    border-radius: 12px;
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-    box-shadow: 0 6px 16px rgba(31, 60, 136, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.sf-content > * {
+    width: 100%;
 }
 
 .sf-scan-header {
@@ -72,6 +95,37 @@ body {
     margin: 0;
     color: #4b5563;
     font-size: 0.95rem;
+}
+
+.sf-search-header h2 {
+    margin: 0;
+    font-size: 1.45rem;
+}
+
+.sf-hint {
+    margin: 0.35rem 0 0;
+    color: #4b5563;
+    font-size: 0.9rem;
+}
+
+.sf-hint code {
+    background: #eef2ff;
+    color: #1f3c88;
+    padding: 0.1rem 0.45rem;
+    border-radius: 6px;
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: 0.85em;
+}
+
+.sf-search-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.sf-search-form .sf-field {
+    margin-bottom: 0;
 }
 
 .sf-scan-actions {
@@ -132,41 +186,87 @@ body {
     margin-bottom: 0.5rem;
 }
 
+.sf-field-label {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: #1f2937;
+}
+
 .sf-field input {
     padding: 0.65rem 0.75rem;
     border: 1px solid #ccd6f6;
-    border-radius: 8px;
-    font-size: 1rem;
+    border-radius: 10px;
+    font-size: 0.95rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.sf-search button {
+.sf-field input:focus {
+    outline: none;
+    border-color: #1f3c88;
+    box-shadow: 0 0 0 3px rgba(31, 60, 136, 0.15);
+}
+
+.sf-checkbox-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.25rem;
+}
+
+.sf-checkbox-group label {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.95rem;
+    color: #1f2937;
+}
+
+.sf-checkbox-group input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+    accent-color: #1f3c88;
+}
+
+.sf-form-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.5rem;
+}
+
+.sf-form-actions button {
     background: #1f3c88;
     color: #fff;
     border: none;
     border-radius: 999px;
-    padding: 0.75rem 1.5rem;
+    padding: 0.7rem 1.6rem;
     font-size: 1rem;
     cursor: pointer;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.sf-search button:hover {
+.sf-form-actions button:hover {
     transform: translateY(-1px);
     box-shadow: 0 8px 16px rgba(31, 60, 136, 0.2);
+}
+
+.sf-results {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
 }
 
 .sf-results table {
     width: 100%;
     border-collapse: collapse;
     background: #ffffff;
-    border-radius: 12px;
+    border-radius: 14px;
     overflow: hidden;
-    box-shadow: 0 6px 16px rgba(31, 60, 136, 0.12);
+    box-shadow: 0 10px 24px rgba(31, 60, 136, 0.12);
+    font-size: 0.85rem;
 }
 
 .sf-results th,
 .sf-results td {
-    padding: 0.85rem 1rem;
+    padding: 0.75rem 1rem;
     text-align: left;
 }
 
@@ -174,8 +274,8 @@ body {
     background: #e9efff;
     color: #1f3c88;
     text-transform: uppercase;
-    font-size: 0.85rem;
-    letter-spacing: 0.05em;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
 }
 
 .sf-results tbody tr:nth-child(odd) {
@@ -183,12 +283,12 @@ body {
 }
 
 .sf-results tbody tr:hover {
-    background: rgba(31, 60, 136, 0.12);
+    background: rgba(31, 60, 136, 0.1);
 }
 
 .sf-path {
     font-family: 'Fira Code', 'Courier New', monospace;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     word-break: break-all;
 }
 
@@ -196,6 +296,107 @@ body {
     text-align: center;
     padding: 2rem !important;
     color: #6b7280;
+}
+
+.sf-results-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.sf-page-size {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: #4b5563;
+}
+
+.sf-page-size label {
+    font-weight: 600;
+}
+
+.sf-page-size select {
+    border: 1px solid #ccd6f6;
+    border-radius: 8px;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.9rem;
+    background: #fff;
+    color: #1f2937;
+}
+
+.sf-results-info {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #1f3c88;
+}
+
+.sf-sort-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    width: 100%;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    text-transform: inherit;
+    letter-spacing: inherit;
+    cursor: pointer;
+}
+
+.sf-sort-button:hover {
+    color: #102a6d;
+}
+
+.sf-sort-button[data-sort-active="true"] {
+    font-weight: 600;
+}
+
+.sf-sort-indicator {
+    font-size: 0.75rem;
+    color: #102a6d;
+}
+
+.sf-pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.sf-pagination button {
+    background: #1f3c88;
+    color: #fff;
+    border: none;
+    border-radius: 999px;
+    padding: 0.55rem 1.25rem;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sf-pagination button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 16px rgba(31, 60, 136, 0.2);
+}
+
+.sf-pagination button:disabled {
+    background: #cbd5f5;
+    color: #6b7280;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.sf-pagination-status {
+    font-size: 0.9rem;
+    color: #4b5563;
+    min-width: 120px;
+    text-align: center;
 }
 
 .error {
@@ -210,7 +411,32 @@ body {
     font-size: 0.85rem;
 }
 
+@media (max-width: 1024px) {
+    .sf-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .sf-side {
+        order: 2;
+    }
+
+    .sf-content {
+        order: 1;
+    }
+}
+
 @media (max-width: 720px) {
+    .sf-results-toolbar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+
+    .sf-pagination {
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
     .sf-results table,
     .sf-results thead,
     .sf-results tbody,

--- a/internal/frontend/templates/index.html
+++ b/internal/frontend/templates/index.html
@@ -13,58 +13,112 @@
         <p class="sf-tagline">极速检索与下载 Linux 文件</p>
     </header>
     <main class="sf-main">
-        <section class="sf-scan">
-            <div class="sf-scan-header">
-                <div>
-                    <h2>扫描控制</h2>
-                    <p class="sf-scan-subtitle">随时启动增量或全量扫描，并查看实时进度</p>
-                </div>
-                <div class="sf-scan-actions">
-                    <button type="button" id="scan-incremental">增量扫描</button>
-                    <button type="button" id="scan-full">全量重建</button>
-                </div>
-            </div>
-            <div id="scan-status" class="sf-scan-status">
-                <p>正在加载扫描状态...</p>
-            </div>
-        </section>
-        <section class="sf-search">
-            <form id="search-form">
-                <div class="sf-field">
-                    <label for="query">关键字</label>
-                    <input id="query" name="query" type="search" placeholder="文件名关键字" />
-                </div>
-                <div class="sf-field-group">
-                    <div class="sf-field">
-                        <label for="min-size">最小大小 (字节)</label>
-                        <input id="min-size" name="minSize" type="number" min="0" />
+        <div class="sf-layout">
+            <aside class="sf-side">
+                <section class="sf-scan">
+                    <div class="sf-scan-header">
+                        <div>
+                            <h2>扫描控制</h2>
+                            <p class="sf-scan-subtitle">启动增量或全量扫描，并实时掌握进度</p>
+                        </div>
+                        <div class="sf-scan-actions">
+                            <button type="button" id="scan-incremental">增量扫描</button>
+                            <button type="button" id="scan-full">全量重建</button>
+                        </div>
                     </div>
-                    <div class="sf-field">
-                        <label for="max-size">最大大小 (字节)</label>
-                        <input id="max-size" name="maxSize" type="number" min="0" />
+                    <div id="scan-status" class="sf-scan-status">
+                        <p>正在加载扫描状态...</p>
+                    </div>
+                </section>
+            </aside>
+            <section class="sf-content">
+                <div class="sf-search-card">
+                    <div class="sf-search-header">
+                        <h2>文件检索</h2>
+                        <p class="sf-hint">支持使用 <code>*</code> 和 <code>?</code> 通配符，例如：<code>*.log</code>、<code>report_??.pdf</code></p>
+                    </div>
+                    <form id="search-form" class="sf-search-form">
+                        <div class="sf-field">
+                            <label for="query">关键字</label>
+                            <input id="query" name="query" type="search" placeholder="输入文件名或通配符" />
+                        </div>
+                        <div class="sf-field-group">
+                            <div class="sf-field">
+                                <label for="min-size">最小大小 (字节)</label>
+                                <input id="min-size" name="minSize" type="number" min="0" />
+                            </div>
+                            <div class="sf-field">
+                                <label for="max-size">最大大小 (字节)</label>
+                                <input id="max-size" name="maxSize" type="number" min="0" />
+                            </div>
+                        </div>
+                        <div class="sf-field">
+                            <span class="sf-field-label">文件类别</span>
+                            <div class="sf-checkbox-group">
+                                <label><input type="checkbox" name="category" value="documents" /> 文档</label>
+                                <label><input type="checkbox" name="category" value="images" /> 图片</label>
+                                <label><input type="checkbox" name="category" value="audio" /> 音频</label>
+                                <label><input type="checkbox" name="category" value="video" /> 视频</label>
+                            </div>
+                        </div>
+                        <div class="sf-form-actions">
+                            <button type="submit">立即检索</button>
+                        </div>
+                    </form>
+                </div>
+                <div class="sf-results">
+                    <div class="sf-results-toolbar">
+                        <div class="sf-page-size">
+                            <label for="page-size">每页显示</label>
+                            <select id="page-size">
+                                <option value="10">10</option>
+                                <option value="20" selected>20</option>
+                                <option value="50">50</option>
+                                <option value="100">100</option>
+                            </select>
+                        </div>
+                        <div class="sf-results-info" id="pagination-info">共 0 条记录</div>
+                    </div>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>
+                                    <button type="button" class="sf-sort-button" data-sort-field="name" aria-sort="none">
+                                        文件名<span class="sf-sort-indicator" aria-hidden="true"></span>
+                                    </button>
+                                </th>
+                                <th>
+                                    <button type="button" class="sf-sort-button" data-sort-field="path" aria-sort="none">
+                                        路径<span class="sf-sort-indicator" aria-hidden="true"></span>
+                                    </button>
+                                </th>
+                                <th>
+                                    <button type="button" class="sf-sort-button" data-sort-field="size" aria-sort="none">
+                                        大小<span class="sf-sort-indicator" aria-hidden="true"></span>
+                                    </button>
+                                </th>
+                                <th>
+                                    <button type="button" class="sf-sort-button" data-sort-field="modified" aria-sort="none">
+                                        修改时间<span class="sf-sort-indicator" aria-hidden="true"></span>
+                                    </button>
+                                </th>
+                                <th>操作</th>
+                            </tr>
+                        </thead>
+                        <tbody id="results-body">
+                            <tr>
+                                <td colspan="5" class="placeholder">请先检索文件</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <div class="sf-pagination">
+                        <button type="button" id="pagination-prev" disabled>上一页</button>
+                        <span class="sf-pagination-status" id="pagination-status">第 1 / 1 页</span>
+                        <button type="button" id="pagination-next" disabled>下一页</button>
                     </div>
                 </div>
-                <button type="submit">检索</button>
-            </form>
-        </section>
-        <section class="sf-results">
-            <table>
-                <thead>
-                    <tr>
-                        <th>文件名</th>
-                        <th>路径</th>
-                        <th>大小</th>
-                        <th>修改时间</th>
-                        <th>操作</th>
-                    </tr>
-                </thead>
-                <tbody id="results-body">
-                    <tr>
-                        <td colspan="5" class="placeholder">请先检索文件</td>
-                    </tr>
-                </tbody>
-            </table>
-        </section>
+            </section>
+        </div>
     </main>
     <footer class="sf-footer">
         <small>© {{.Year}} SeekFile</small>
@@ -73,18 +127,33 @@
     (function() {
         const form = document.getElementById('search-form');
         const tbody = document.getElementById('results-body');
+        const paginationInfo = document.getElementById('pagination-info');
+        const paginationStatus = document.getElementById('pagination-status');
+        const paginationPrev = document.getElementById('pagination-prev');
+        const paginationNext = document.getElementById('pagination-next');
+        const pageSizeSelect = document.getElementById('page-size');
+        const sortButtons = document.querySelectorAll('.sf-sort-button');
         const scanStatusBox = document.getElementById('scan-status');
         const incrementalButton = document.getElementById('scan-incremental');
         const fullButton = document.getElementById('scan-full');
         let statusTimer = null;
 
+        const state = {
+            page: 1,
+            pageSize: parseInt(pageSizeSelect.value, 10) || 20,
+            sortField: 'name',
+            sortOrder: 'asc',
+            total: 0,
+            totalPages: 0
+        };
+
         function formatSize(bytes) {
-            if (bytes === 0) return '0 B';
+            if (!bytes) return '0 B';
             const units = ['B', 'KB', 'MB', 'GB', 'TB'];
             const k = 1024;
-            const i = Math.floor(Math.log(bytes) / Math.log(k));
+            const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(k)));
             const value = bytes / Math.pow(k, i);
-            return value.toFixed(1) + ' ' + units[i];
+            return value.toFixed(value < 10 && i > 0 ? 2 : 1) + ' ' + units[i];
         }
 
         function formatDate(value) {
@@ -100,15 +169,29 @@
             return date.toLocaleString();
         }
 
+        function ensurePageSizeOption(value) {
+            if (!value) return;
+            const stringValue = String(value);
+            const hasOption = Array.from(pageSizeSelect.options).some(option => option.value === stringValue);
+            if (!hasOption) {
+                const option = document.createElement('option');
+                option.value = stringValue;
+                option.textContent = stringValue;
+                pageSizeSelect.appendChild(option);
+            }
+            pageSizeSelect.value = stringValue;
+        }
+
         function renderRows(files) {
             tbody.innerHTML = '';
-            if (!files.length) {
+            if (!Array.isArray(files) || !files.length) {
                 const row = document.createElement('tr');
                 row.innerHTML = '<td colspan="5" class="placeholder">未找到匹配文件</td>';
                 tbody.appendChild(row);
                 return;
             }
 
+            const fragment = document.createDocumentFragment();
             files.forEach(file => {
                 const row = document.createElement('tr');
                 const link = `/api/download?path=${encodeURIComponent(file.path)}`;
@@ -119,8 +202,110 @@
                     <td data-label="修改时间">${formatDate(file.modified)}</td>
                     <td data-label="操作"><a href="${link}" download>下载</a></td>
                 `;
-                tbody.appendChild(row);
+                fragment.appendChild(row);
             });
+            tbody.appendChild(fragment);
+        }
+
+        function updatePaginationMeta(data) {
+            if (typeof data.pageSize === 'number' && data.pageSize > 0) {
+                state.pageSize = data.pageSize;
+                ensurePageSizeOption(state.pageSize);
+            }
+            if (typeof data.page === 'number' && data.page > 0) {
+                state.page = data.page;
+            }
+            if (typeof data.total === 'number' && data.total >= 0) {
+                state.total = data.total;
+            }
+            if (typeof data.totalPages === 'number' && data.totalPages >= 0) {
+                state.totalPages = data.totalPages;
+            } else if (state.pageSize > 0) {
+                state.totalPages = Math.ceil(state.total / state.pageSize);
+            }
+            if (typeof data.sort === 'string' && data.sort) {
+                state.sortField = data.sort;
+            }
+            if (typeof data.order === 'string' && data.order) {
+                state.sortOrder = data.order.toLowerCase() === 'desc' ? 'desc' : 'asc';
+            }
+        }
+
+        function updatePaginationControls() {
+            const totalPages = state.totalPages || (state.pageSize > 0 ? Math.ceil(state.total / state.pageSize) : 0);
+            state.totalPages = totalPages;
+            const displayTotalPages = totalPages > 0 ? totalPages : 1;
+            const displayPage = totalPages > 0 ? Math.min(state.page, totalPages) : 1;
+
+            paginationInfo.textContent = `共 ${state.total} 条记录`;
+            paginationStatus.textContent = `第 ${displayPage} / ${displayTotalPages} 页`;
+
+            const disablePrev = displayPage <= 1 || totalPages <= 1;
+            const disableNext = totalPages <= 1 || displayPage >= totalPages;
+            paginationPrev.disabled = disablePrev;
+            paginationNext.disabled = disableNext;
+        }
+
+        function updateSortIndicators() {
+            sortButtons.forEach(button => {
+                const field = button.dataset.sortField;
+                const isActive = field === state.sortField;
+                button.dataset.sortActive = isActive ? 'true' : 'false';
+                button.dataset.sortOrder = isActive ? state.sortOrder : '';
+                button.setAttribute('aria-sort', isActive ? (state.sortOrder === 'desc' ? 'descending' : 'ascending') : 'none');
+                const indicator = button.querySelector('.sf-sort-indicator');
+                if (indicator) {
+                    indicator.textContent = isActive ? (state.sortOrder === 'desc' ? '↓' : '↑') : '';
+                }
+            });
+        }
+
+        function buildSearchParams() {
+            const params = new URLSearchParams();
+            const formData = new FormData(form);
+            formData.forEach((value, key) => {
+                if (!value) return;
+                if (key === 'category') {
+                    params.append(key, value);
+                } else {
+                    params.set(key, value);
+                }
+            });
+            params.set('page', state.page);
+            params.set('pageSize', state.pageSize);
+            params.set('sort', state.sortField);
+            params.set('order', state.sortOrder);
+            return params;
+        }
+
+        function performSearch(options = {}) {
+            if (options.resetPage) {
+                state.page = 1;
+            }
+
+            paginationInfo.textContent = '正在检索...';
+            paginationStatus.textContent = '';
+            paginationPrev.disabled = true;
+            paginationNext.disabled = true;
+            tbody.innerHTML = '<tr><td colspan="5" class="placeholder">正在检索...</td></tr>';
+
+            const params = buildSearchParams();
+            fetch('/api/search?' + params.toString())
+                .then(response => {
+                    if (!response.ok) throw new Error('搜索失败');
+                    return response.json();
+                })
+                .then(data => {
+                    updatePaginationMeta(data || {});
+                    renderRows((data && data.files) || []);
+                    updatePaginationControls();
+                    updateSortIndicators();
+                })
+                .catch(error => {
+                    tbody.innerHTML = '<tr><td colspan="5" class="error">' + error.message + '</td></tr>';
+                    paginationInfo.textContent = '检索失败';
+                    paginationStatus.textContent = '';
+                });
         }
 
         function setScanButtonsDisabled(disabled) {
@@ -200,21 +385,44 @@
 
         form.addEventListener('submit', function(event) {
             event.preventDefault();
-            const formData = new FormData(form);
-            const params = new URLSearchParams();
-            for (const [key, value] of formData.entries()) {
-                if (value) params.append(key, value);
-            }
+            performSearch({ resetPage: true });
+        });
 
-            fetch('/api/search?' + params.toString())
-                .then(response => {
-                    if (!response.ok) throw new Error('搜索失败');
-                    return response.json();
-                })
-                .then(data => renderRows(data.files || []))
-                .catch(error => {
-                    tbody.innerHTML = '<tr><td colspan="5" class="error">' + error.message + '</td></tr>';
-                });
+        pageSizeSelect.addEventListener('change', function() {
+            const value = parseInt(this.value, 10);
+            if (!Number.isNaN(value)) {
+                state.pageSize = value;
+                performSearch({ resetPage: true });
+            }
+        });
+
+        paginationPrev.addEventListener('click', function() {
+            if (state.page > 1) {
+                state.page -= 1;
+                performSearch();
+            }
+        });
+
+        paginationNext.addEventListener('click', function() {
+            if (state.totalPages === 0 || state.page >= state.totalPages) {
+                return;
+            }
+            state.page += 1;
+            performSearch();
+        });
+
+        sortButtons.forEach(button => {
+            button.addEventListener('click', function() {
+                const field = this.dataset.sortField;
+                if (!field) return;
+                if (state.sortField === field) {
+                    state.sortOrder = state.sortOrder === 'asc' ? 'desc' : 'asc';
+                } else {
+                    state.sortField = field;
+                    state.sortOrder = 'asc';
+                }
+                performSearch({ resetPage: true });
+            });
         });
 
         incrementalButton.addEventListener('click', function() {
@@ -225,6 +433,7 @@
             triggerScan('full');
         });
 
+        updateSortIndicators();
         fetchScanStatus();
         statusTimer = setInterval(fetchScanStatus, 5000);
     })();


### PR DESCRIPTION
## Summary
- extend the search API with pagination, category filtering by extension, and server-side sorting support
- enhance the indexer to page results, honor wildcard patterns, and compare records by different fields
- refresh the frontend with a two-column layout, sortable columns, pagination controls, and wildcard-aware inputs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d8a58defac832da6a16a03a468adb3