### PR TITLE
Refine search layout and pagination defaults

### DIFF
--- a/internal/frontend/static/styles.css
+++ b/internal/frontend/static/styles.css
@@ -42,8 +42,8 @@ body {
 
 .sf-layout {
     display: grid;
-    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-    gap: 1.5rem;
+    grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+    gap: 1.75rem;
     align-items: flex-start;
 }
 
@@ -54,6 +54,10 @@ body {
     gap: 1.5rem;
 }
 
+.sf-side {
+    gap: 1.5rem;
+}
+
 .sf-search-card,
 .sf-results,
 .sf-scan {
@@ -61,6 +65,12 @@ body {
     border-radius: 16px;
     padding: 1.75rem;
     box-shadow: 0 18px 32px rgba(31, 60, 136, 0.12);
+}
+
+.sf-results {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
 .sf-search-card {
@@ -248,12 +258,6 @@ body {
     box-shadow: 0 8px 16px rgba(31, 60, 136, 0.2);
 }
 
-.sf-results {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-}
-
 .sf-results table {
     width: 100%;
     border-collapse: collapse;
@@ -261,12 +265,12 @@ body {
     border-radius: 14px;
     overflow: hidden;
     box-shadow: 0 10px 24px rgba(31, 60, 136, 0.12);
-    font-size: 0.85rem;
+    font-size: 0.8rem;
 }
 
 .sf-results th,
 .sf-results td {
-    padding: 0.75rem 1rem;
+    padding: 0.6rem 0.85rem;
     text-align: left;
 }
 
@@ -274,7 +278,7 @@ body {
     background: #e9efff;
     color: #1f3c88;
     text-transform: uppercase;
-    font-size: 0.75rem;
+    font-size: 0.7rem;
     letter-spacing: 0.08em;
 }
 
@@ -328,7 +332,7 @@ body {
 }
 
 .sf-results-info {
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     font-weight: 600;
     color: #1f3c88;
 }
@@ -393,7 +397,7 @@ body {
 }
 
 .sf-pagination-status {
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     color: #4b5563;
     min-width: 120px;
     text-align: center;
@@ -417,11 +421,11 @@ body {
     }
 
     .sf-side {
-        order: 2;
+        order: 1;
     }
 
     .sf-content {
-        order: 1;
+        order: 2;
     }
 }
 

--- a/internal/frontend/templates/index.html
+++ b/internal/frontend/templates/index.html
@@ -30,9 +30,7 @@
                         <p>正在加载扫描状态...</p>
                     </div>
                 </section>
-            </aside>
-            <section class="sf-content">
-                <div class="sf-search-card">
+                <section class="sf-search-card">
                     <div class="sf-search-header">
                         <h2>文件检索</h2>
                         <p class="sf-hint">支持使用 <code>*</code> 和 <code>?</code> 通配符，例如：<code>*.log</code>、<code>report_??.pdf</code></p>
@@ -65,15 +63,17 @@
                             <button type="submit">立即检索</button>
                         </div>
                     </form>
-                </div>
+                </section>
+            </aside>
+            <section class="sf-content">
                 <div class="sf-results">
                     <div class="sf-results-toolbar">
                         <div class="sf-page-size">
                             <label for="page-size">每页显示</label>
                             <select id="page-size">
                                 <option value="10">10</option>
-                                <option value="20" selected>20</option>
-                                <option value="50">50</option>
+                                <option value="20">20</option>
+                                <option value="50" selected>50</option>
                                 <option value="100">100</option>
                             </select>
                         </div>
@@ -140,7 +140,7 @@
 
         const state = {
             page: 1,
-            pageSize: parseInt(pageSizeSelect.value, 10) || 20,
+            pageSize: parseInt(pageSizeSelect.value, 10) || 50,
             sortField: 'name',
             sortOrder: 'asc',
             total: 0,


### PR DESCRIPTION
## Summary
- move the search form into the left control column so the right pane focuses on results
- tighten table typography and reduce default font size to fit more entries per page
- raise the default page size to 50 items for denser result views

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d8a9a0e2a4832d872413e103d42214